### PR TITLE
Undefined or null check on symbol

### DIFF
--- a/typedoc-plugin-external-module-name.ts
+++ b/typedoc-plugin-external-module-name.ts
@@ -197,9 +197,11 @@ function updateSymbolMapping(context: Context, symbol: ts.Symbol, reflection: Re
     // (context as any).registerReflection(reflection, null, symbol);
     (context.project as any).symbolMapping[(symbol as any).id] = reflection.id;
   } else {
-    // context.registerReflection(reflection, symbol);
-    const fqn = context.checker.getFullyQualifiedName(symbol);
-    (context.project as any).fqnToReflectionIdMap.set(fqn, reflection.id);
+    if (symbol) {
+      // context.registerReflection(reflection, symbol);
+      const fqn = context.checker.getFullyQualifiedName(symbol);
+      (context.project as any).fqnToReflectionIdMap.set(fqn, reflection.id);
+    }
   }
 }
 


### PR DESCRIPTION
In some cases, when generating the documentation, it can fail with the following error

```
return symbol.parent ? getFullyQualifiedName(symbol.parent, containingLocation) + "." + symbolToString(symbol) : symbolToString(symbol, containingLocation, /*meaning*/ undefined, 16 /* DoNotIncludeSymbolChain */ | 4 /* AllowAnyNodeKind */);
              ^

TypeError: Cannot read property 'parent' of undefined
    at Object.getFullyQualifiedName (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typescript\lib\typescript.js:35258:27)
    at updateSymbolMapping (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc-plugin-external-module-name\plugin.js:201:41)
    at moduleRenames.forEach.item (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc-plugin-external-module-name\plugin.js:149:17)
    at Array.forEach (<anonymous>)
    at ExternalModuleNamePlugin.onBeginResolve (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc-plugin-external-module-name\plugin.js:111:32)
    at triggerEvents (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc\dist\lib\utils\events.js:128:43)
    at triggerApi (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc\dist\lib\utils\events.js:110:13)
    at eventsApi (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc\dist\lib\utils\events.js:21:18)
    at Converter.trigger (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc\dist\lib\utils\events.js:264:13)
    at Converter.resolve (D:\SPFx\BPA-SPFx-PeoplePicker\node_modules\typedoc\dist\lib\converter\converter.js:180:14)
```
Reason being the `symbol` object being undefined.

This PR adds a guard with a check on the symbol. If it is not undefined or null, then it can proceed with the generation.